### PR TITLE
Changes to make the project compile with opencv4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,7 @@ AS_IF([case $host_os in darwin*) true;; *) false;; esac],
   ]
 )
 
-m4_ifdef([PKG_CHECK_MODULES], [PKG_CHECK_MODULES([OPENCV], [opencv >= 2.0], [], [AC_MSG_RESULT([Opencl not present.])])])
+m4_ifdef([PKG_CHECK_MODULES], [PKG_CHECK_MODULES([OPENCV], [opencv4 >= 2.0], [], [AC_MSG_RESULT([Opencl not present.])])])
 
 
 AC_SUBST([OPENCV_CFLAGS])

--- a/src/facetrack.cpp
+++ b/src/facetrack.cpp
@@ -3,6 +3,7 @@
 #include "facetrack.h"
 #include "wc_driver_prefs.h"
 
+#include <opencv2/core/core_c.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/objdetect/objdetect.hpp>
 #include <opencv2/imgproc/imgproc.hpp>


### PR DESCRIPTION
With this change the project should compile with opencv4 (tested with archlinux && ubuntu 20.04)

Don't forget to do aclocal autoconf && automake before compiling

Regards,
Rodrigo