### PR TITLE
Update ltr_srv_master.cpp

### DIFF
--- a/src/ltr_srv_master.cpp
+++ b/src/ltr_srv_master.cpp
@@ -1,3 +1,4 @@
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "ltr_srv_comm.h"


### PR DESCRIPTION
added #include <pthread.h> due this error during compile: ‘PTHREAD_MUTEX_INITIALIZER’ was not declared in this scope;